### PR TITLE
Stop the update rate limit hiding an update we already found

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/utils/UpdateChecker.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/UpdateChecker.kt
@@ -75,7 +75,24 @@ class UpdateChecker @Inject constructor(
 
         val last = store.get(LastUpdateCheckKey, 0L)
         val now = System.currentTimeMillis()
-        if (!force && now - last < MIN_CHECK_INTERVAL_MS) {
+
+        // The interval is stored on disk but the result it protects is only in memory, so the two
+        // disagree after the process is killed: a cold start inside the interval skipped the
+        // request and handed back a null _available for an update the app already knows about.
+        // UpdateAvailableKey (persisted, and what the search-bar badge reads) still said one
+        // existed, so the badge advertised an update the Updates screen would not show and the
+        // "skip this version" control could not be reached, for up to MIN_CHECK_INTERVAL_MS.
+        //
+        // So skip the request only when it would tell us nothing new: either the answer is still
+        // in memory, or the persisted flag says there was no update to hold. That leaves the rate
+        // limit fully in force for the ordinary case of nothing pending, and costs at most one
+        // request per cold start while an undismissed update is outstanding. It also lets the
+        // badge clear itself on the first open after the user actually updates, instead of
+        // sitting there stale until the interval elapses.
+        val knownAvailable = store.get(UpdateAvailableKey, false)
+        if (!force && now - last < MIN_CHECK_INTERVAL_MS &&
+            (_available.value != null || !knownAvailable)
+        ) {
             return@withContext _available.value
         }
 


### PR DESCRIPTION
Fixes #4. Found by the proactive bug scan (routine N2-A), not by a report.

## ⚠️ UNVERIFIED — not compiled

`:app:compileCoreDebugKotlin` was attempted twice here and could not run. The second attempt resolved all dependencies and then stopped at the real blocker:

```
* What went wrong:
A problem occurred configuring project ':ffMetadataEx'.
> SDK location not found. Define a valid SDK location with an ANDROID_HOME environment
  variable or by setting the sdk.dir path in your project's local properties file at
  '/home/user/InterTune/local.properties'.

BUILD FAILED in 1m 16s
```

There is no Android SDK in this environment — `ANDROID_HOME` and `ANDROID_SDK_ROOT` are unset and nothing is present at `~/Android/Sdk`, `/usr/lib/android-sdk` or `/opt/android-sdk`. (The first attempt failed earlier still, on a transient `429 Too Many Requests` from Maven Central; that cleared on the retry.)

No unit test either: `:app` has no JVM test source set, and `UpdateChecker` needs `Context` and a DataStore, so it is not testable without Robolectric or instrumentation.

What that leaves: a single added boolean condition, using `UpdateAvailableKey`, which the file already imports at line 16. **Please build and run the device plan below before treating this as done.**

## Root cause

The rate limit between update checks is keyed on `LastUpdateCheckKey`, which is persisted to DataStore. The value it hands back instead of making a request is `_available.value` — a `MutableStateFlow<Update?>` on the `@Singleton`, which is process memory and starts at `null`.

Nothing rehydrates it. `check()` is the flow's only writer, and the only update state that survives the process is `UpdateAvailableKey` / `LastVersionKey` — which is what the **badge** reads (`SearchScreen.kt:91`, `SettingsScreen.kt:79`), while the Updates screen reads the **in-memory flow** (`UpdateSettings.kt:70`).

So after the process is killed, a cold start inside the interval takes this branch:

```kotlin
if (!force && now - last < MIN_CHECK_INTERVAL_MS) {
    return@withContext _available.value   // null on a fresh process
}
```

and the two halves disagree for up to six hours: the badge advertises an update, Settings → Updates renders no card, and "Skip this version" lives inside that card so it cannot be reached. The only escape is the manual "Check for update" button, which passes `force = true`.

Same branch, second consequence: after the user actually installs the update, the first open inside the interval also skips the request, so `clearAvailable()` never runs and the stale badge survives until the interval elapses.

## The change

Skip the request only when doing so would tell us nothing new — the answer is still in memory, or the persisted flag says there was no update to hold:

```kotlin
val knownAvailable = store.get(UpdateAvailableKey, false)
if (!force && now - last < MIN_CHECK_INTERVAL_MS &&
    (_available.value != null || !knownAvailable)
) {
    return@withContext _available.value
}
```

One file, one condition, no new preference key, no API or schema change.

**On request volume**, since that is what the rate limit is for (60 unauthenticated GitHub requests an hour per IP, shared behind carrier NAT):

- No update pending — `UpdateAvailableKey` is false, the condition is unchanged, the rate limit behaves exactly as before. This is the overwhelmingly common case.
- Update pending and undismissed — one extra request per cold start, and that check repopulates `_available`, so the first half of the disjunction short-circuits for the rest of the process.
- Update dismissed — `dismiss()` sets `UpdateAvailableKey = false`, so a dismissed version does not hold the door open.
- Offline — `check()` already returns before this branch when there is no connectivity.
- Request fails — `_available` stays null and `LastUpdateCheckKey` is deliberately not stamped, so the next app open retries. Bounded by app opens, not by a timer.

Rejected as larger: persisting `versionCode` and `releaseUrl` to rehydrate `_available` at construction needs two new preference keys and more state to keep in sync, for a case one extra condition already covers.

## Device test plan — Galaxy S25 Ultra

1. Settings → Updates → turn "Check for updates" on. Confirm the update card appears. (Needs a release newer than the installed `versionCode`; otherwise install an older build first.)
2. Do **not** dismiss it. Force stop InterTune from Android Settings → Apps, so the process really dies rather than being backgrounded.
3. Reopen within 6 hours.
   - Before this change: badge on the search bar, but Settings → Updates shows no card.
   - After: the card is there and "Skip this version" works.
4. Tap "Skip this version". Force stop, reopen inside the interval. Expect no card and no badge, and confirm via logcat (tag `UpdateChecker`) that **no** request went out — the rate limit must still hold for the dismissed case.
5. Turn update checks off. Force stop, reopen, confirm nothing is fetched at all.
6. With no update pending, force stop and reopen several times inside the interval. Confirm from logcat that only the first open fetched — the rate limit must be intact for the ordinary case. This is the regression that matters most.
7. Optional, for the secondary fix: with an update pending, install it, then reopen inside the interval and confirm the badge clears itself instead of lingering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvJ88e8QnffJMFCDFfRLPh