### PR TITLE
Bug scan bookkeeping — baseline and index (2026-09-01)

### DIFF
--- a/.bug-scan/RUNLOG.md
+++ b/.bug-scan/RUNLOG.md
@@ -1,0 +1,12 @@
+# Bug scan run log
+
+Routine N2-A — proactive hunt for unreported bugs in this fork's own code.
+Scope is our divergence from `OuterTune/OuterTune`, not upstream's code.
+
+2026-09-01 — full sweep (run 1) of `visionos-fix` @ `de158cf`, surface computed as the tree
+diff against `OuterTune/OuterTune@dev` (`12f61da`): 7 fork-only `*.kt` files plus 45
+modified ones, read in risk order (playback, media session, coroutine managers, DAO,
+scanners, then UI). 3 findings, all new; 7 candidates discarded, 4 of them because they
+turned out to be unchanged upstream code. Issues #4, #5, #6. Draft PR #7 for the one
+finding that cleared 80/100. Build capability: none — no Android SDK in this environment,
+so the patch is UNVERIFIED.

--- a/.bug-scan/baseline.json
+++ b/.bug-scan/baseline.json
@@ -1,0 +1,125 @@
+{
+  "schema": 1,
+  "note": "Every finding ever surfaced by the proactive bug scan (routine N2-A), keyed by fingerprint. Fingerprint = <path>#<enclosing symbol>#<bug class>. Never re-report a fingerprint whose state is reported, patched, wontfix or accepted.",
+  "findings": [
+    {
+      "fingerprint": "app/src/main/java/com/dd3boh/outertune/utils/UpdateChecker.kt#check#logic",
+      "file": "app/src/main/java/com/dd3boh/outertune/utils/UpdateChecker.kt",
+      "line": 76,
+      "symbol": "check",
+      "bug_class": "logic",
+      "summary": "The update-check rate limit is keyed on a persisted timestamp but guards an in-memory result, so a cold start inside the interval returns null for an update the app already knows about. The badge (persisted) advertises it while Settings -> Updates (in memory) shows nothing and the skip control is unreachable.",
+      "score": 81,
+      "score_breakdown": {
+        "failure_path_clarity": 25,
+        "localization": 25,
+        "blast_radius": 25,
+        "verifiability": 6
+      },
+      "state": "patched",
+      "issue": 4,
+      "pr": 7,
+      "pr_state": "draft",
+      "verified": false,
+      "plan": ".bug-scan/plans/UpdateChecker.kt--check--logic.md",
+      "first_seen": "2026-09-01",
+      "run": 1
+    },
+    {
+      "fingerprint": "app/src/main/java/com/dd3boh/outertune/utils/LoudnessRepair.kt#cancel#concurrency",
+      "file": "app/src/main/java/com/dd3boh/outertune/utils/LoudnessRepair.kt",
+      "line": 212,
+      "symbol": "cancel",
+      "bug_class": "concurrency",
+      "summary": "cancel() nulls the job before the coroutine has stopped, so isRunning under-reports while the cancelled run is still inside an in-flight request. Tapping the settings row again starts a second scan concurrently: the request pacing doubles and the plain LinkedHashSet 'unavailable' is mutated from two coroutines on Dispatchers.IO.",
+      "score": 76,
+      "score_breakdown": {
+        "failure_path_clarity": 20,
+        "localization": 25,
+        "blast_radius": 25,
+        "verifiability": 6
+      },
+      "state": "reported",
+      "issue": 5,
+      "pr": null,
+      "verified": false,
+      "not_patched_reason": "Scored below the 80 patch bar, and the run's single code PR went to the higher-scoring finding.",
+      "first_seen": "2026-09-01",
+      "run": 1
+    },
+    {
+      "fingerprint": "app/src/main/java/com/dd3boh/outertune/MainActivity.kt#onCreate.dynamicThemeEffect#concurrency",
+      "file": "app/src/main/java/com/dd3boh/outertune/MainActivity.kt",
+      "line": 363,
+      "symbol": "onCreate / LaunchedEffect(playerConnection, enableDynamicTheme, isSystemInDarkTheme)",
+      "bug_class": "concurrency",
+      "summary": "The artwork-colour extraction launches into an outer coroutine scope from inside collectLatest, so collectLatest has nothing left to cancel. The launched work is never cancelled and its completions are unordered, so a stale song's colour can win and a colour can land after the user has switched dynamic theme off.",
+      "score": 78,
+      "score_breakdown": {
+        "failure_path_clarity": 22,
+        "localization": 25,
+        "blast_radius": 25,
+        "verifiability": 6
+      },
+      "state": "reported",
+      "issue": 6,
+      "pr": null,
+      "verified": false,
+      "not_patched_reason": "Scored below the 80 patch bar, and the run's single code PR went to the higher-scoring finding.",
+      "provenance_note": "The collectLatest { scope.launch { } } shape is inherited verbatim from upstream's ui/theme/Theme.kt; the fork relocated it into MainActivity.kt during the theming rework. Filed because it now lives in our file and affects our users, not as a claim that the fork introduced it.",
+      "first_seen": "2026-09-01",
+      "run": 1
+    }
+  ],
+  "discarded": [
+    {
+      "file": "app/src/main/java/com/dd3boh/outertune/ui/utils/GlassBackdrop.kt",
+      "symbol": "rememberGlassSpec",
+      "candidate": "Conditional early return placed before a remember call (rememberPreference), which looked like a slot-table hazard.",
+      "verdict": "false-positive",
+      "reason": "The Compose compiler supports early returns from composables by emitting group end markers, so the slot table stays consistent. No failure path."
+    },
+    {
+      "file": "app/src/main/java/com/dd3boh/outertune/playback/SleepTimer.kt",
+      "symbol": "start",
+      "candidate": "'while (isActive && pauseWhenSongEnd)' inside scope.launch, where the class also declares its own isActive property, so the two could be confused.",
+      "verdict": "false-positive",
+      "reason": "Ambiguous to read but harmless. Kotlin resolves to CoroutineScope.isActive (an extension on the innermost implicit receiver beats a member of an outer one), and either reading terminates the loop correctly anyway."
+    },
+    {
+      "file": "app/src/main/java/com/dd3boh/outertune/ui/screens/settings/UpdateSettings.kt",
+      "symbol": "UpdateSettings",
+      "candidate": "'checking' is not reset in a finally, so a throw from check() would leave the row permanently disabled.",
+      "verdict": "wontfix-thin",
+      "reason": "Real but the throw surface is only a DataStore IO error, and cancellation takes the whole composition with it. No concrete failure path worth an issue on its own."
+    },
+    {
+      "file": "app/src/main/java/com/dd3boh/outertune/utils/CoilBitmapLoader.kt",
+      "symbol": "fetch",
+      "candidate": "MediaMetadataRetriever is constructed and never released, leaking a native handle on every local-artwork fetch.",
+      "verdict": "out-of-scope",
+      "reason": "Verbatim upstream code; the fork's diff of this file against OuterTune@dev is empty. Belongs to the upstream-issue routine (N1), not to this scan."
+    },
+    {
+      "file": "app/src/main/java/com/dd3boh/outertune/MainActivity.kt",
+      "symbol": "onCreate",
+      "candidate": "connectivityObserver is unregistered and re-registered inside the setContent composable body, so it re-registers on recomposition.",
+      "verdict": "out-of-scope",
+      "reason": "Unchanged upstream code (appears only as diff context). N1 territory."
+    },
+    {
+      "file": "app/src/main/java/com/dd3boh/outertune/ui/component/AnchorDraggable.kt",
+      "symbol": "SwipeActionBox",
+      "candidate": "Swipe offsets are computed from dp values but fed to Modifier.offset {}, which takes pixels.",
+      "verdict": "out-of-scope",
+      "reason": "Pre-existing upstream behaviour; the fork only swapped the dp source from BoxWithConstraints.maxWidth to screenWidthDp. Not fork-introduced."
+    },
+    {
+      "file": "app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt",
+      "symbol": "BottomSheetPlayer / gradient colours LaunchedEffect",
+      "candidate": "gradientColors keeps the previous song's colours when extraction is skipped (power saver, non-GRADIENT style) or when the artwork fetch fails.",
+      "verdict": "wontfix-thin",
+      "reason": "Cosmetic and only visible in the background gradient. No crash, leak or data error; below the bar for an issue."
+    }
+  ]
+}

--- a/.bug-scan/index.json
+++ b/.bug-scan/index.json
@@ -1,0 +1,28 @@
+{
+  "meta": {
+    "last_scanned_sha": "de158cf58fa55fcdc5c50fd0d8511fbccdcc536e",
+    "last_scanned_branch": "visionos-fix",
+    "last_full_sweep": "2026-09-01",
+    "last_run": "2026-09-01",
+    "run_count": 1,
+    "build_capability": "none",
+    "build_capability_evidence": {
+      "task": ":app:compileCoreDebugKotlin",
+      "result": "FAILURE",
+      "cause": "SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file at '/home/user/InterTune/local.properties'. (configuring project ':ffMetadataEx')",
+      "notes": [
+        "ANDROID_HOME and ANDROID_SDK_ROOT are unset; no SDK at ~/Android/Sdk, /usr/lib/android-sdk or /opt/android-sdk.",
+        "A first attempt failed earlier still, on a transient 429 Too Many Requests from Maven Central via the agent proxy. Dependency resolution succeeded on retry, so the SDK is the real blocker.",
+        "Submodules taglib and ffMetadataEx were absent on checkout and were self-healed with 'git submodule update --init --recursive --depth 1'.",
+        "Consequence: every patch produced in this environment is UNVERIFIED, and the Verifiability dimension cannot score above 6/25 for anything that is not pure JVM logic. :app has no JVM unit-test source set either; only :innertube and :kugou do."
+      ]
+    },
+    "scan_surface_method": {
+      "description": "The repo is a shallow clone (54 commits) with no common ancestor available for OuterTune/OuterTune, so merge-base does not work. The fork's own surface was computed instead as a tree diff of HEAD against a read-only fetch of OuterTune/OuterTune@dev.",
+      "upstream_ref_fetched": "12f61da05f82fdb870c97dcc89c847ce29c75428",
+      "fork_only_files": 7,
+      "modified_vs_upstream_kt_files": 45,
+      "note": "Upstream was fetched read-only via 'git fetch <url> dev' without adding a remote. Nothing was written to OuterTune/OuterTune."
+    }
+  }
+}

--- a/.bug-scan/plans/UpdateChecker.kt--check--logic.md
+++ b/.bug-scan/plans/UpdateChecker.kt--check--logic.md
@@ -1,0 +1,120 @@
+# Plan — `UpdateChecker.check()` hides a known update after a cold start
+
+Fingerprint: `app/src/main/java/com/dd3boh/outertune/utils/UpdateChecker.kt` + `check` + `logic`
+
+## Root cause
+
+`app/src/main/java/com/dd3boh/outertune/utils/UpdateChecker.kt:76`
+
+```kotlin
+val last = store.get(LastUpdateCheckKey, 0L)
+val now = System.currentTimeMillis()
+if (!force && now - last < MIN_CHECK_INTERVAL_MS) {
+    return@withContext _available.value
+}
+```
+
+The rate limit is keyed on `LastUpdateCheckKey`, which is **persisted in DataStore**
+(`UpdateChecker.kt:99`). The value it returns instead of making the request is
+`_available.value`, a `MutableStateFlow<Update?>` held on the `@Singleton`
+(`UpdateChecker.kt:52`), which is **process memory** and starts at `null` on every cold
+start.
+
+Nothing rehydrates `_available`. `check()` is the only writer, and the only other update
+state that survives the process is `UpdateAvailableKey` / `LastVersionKey`
+(`UpdateChecker.kt:117-120`) — which is what the *badge* reads
+(`SearchScreen.kt:91`, `SettingsScreen.kt:79`), while the Updates screen reads the
+in-memory flow (`UpdateSettings.kt:70`).
+
+So the persisted half and the in-memory half disagree for up to `MIN_CHECK_INTERVAL_MS`
+(6 hours) after every cold start.
+
+## Failure scenario
+
+Preconditions: the user has opted in to update checks (`UpdateCheckEnabledKey = true`).
+
+1. 10:00 — app opens. `MainActivity` calls `updateChecker.check()` (force = false,
+   `MainActivity.kt:333`). A newer release is found: `_available` is set,
+   `LastUpdateCheckKey = 10:00`, `UpdateAvailableKey = true`, `LastVersionKey` written.
+2. The user does not act on it. The app is closed and the process is killed.
+3. 11:00 — app reopens. `check()` runs again with force = false. `now - last` is 1 h,
+   under the 6 h interval, so it returns `_available.value` — `null` on this fresh
+   process. No request is made and no state is populated.
+4. The search bar and Settings still show the update badge, because those read the
+   persisted `UpdateAvailableKey`. Settings → Updates shows **no** update card, because
+   it reads `updateChecker.available`. The "Skip this version" control lives inside that
+   card and is therefore unreachable.
+
+Wrong outcome: the app tells the user an update exists in one place and denies it in
+another, and the dismiss path cannot be reached, until either 6 hours pass or the user
+finds the manual "Check for update" button (which passes `force = true`).
+
+A second, related consequence: after the user actually installs the update, the first
+open inside the interval also skips the request, so `clearAvailable()` never runs and the
+stale badge survives until the interval elapses.
+
+## The minimal change
+
+Skip the request only when doing so would tell us nothing new — that is, when the answer
+is still in memory, or when the persisted flag says there was no update to hold on to:
+
+```kotlin
+val knownAvailable = store.get(UpdateAvailableKey, false)
+if (!force && now - last < MIN_CHECK_INTERVAL_MS &&
+    (_available.value != null || !knownAvailable)
+) {
+    return@withContext _available.value
+}
+```
+
+One file, one condition, no new preference key, no API change. `UpdateAvailableKey` is
+already imported.
+
+Rejected alternative: persist `versionCode` and `releaseUrl` and rehydrate `_available`
+at construction. That is strictly more state to keep in sync and needs two new preference
+keys, to fix a case a single extra condition already covers.
+
+Rejected alternative: drop or shorten the rate limit. It exists because the GitHub API
+allows 60 unauthenticated requests an hour per IP and everyone behind one carrier NAT
+shares that budget (`UpdateChecker.kt:64-70`). It should stay.
+
+## What could regress
+
+- **Request volume.** In the common case (no update pending) `UpdateAvailableKey` is
+  false, so the condition is unchanged and the rate limit is exactly as before. The extra
+  request only happens while an undismissed update is outstanding, and only once per cold
+  start: the first successful check repopulates `_available`, after which the first half
+  of the disjunction short-circuits for the rest of the process.
+- **Dismissed updates.** `dismiss()` sets `UpdateAvailableKey = false`
+  (`UpdateChecker.kt:128-134`), so a dismissed version does not keep the door open.
+- **Offline cold starts.** `check()` already returns early when there is no connectivity
+  (`UpdateChecker.kt:74`), before this branch is reached.
+- **A failed request.** `_available` stays null and `LastUpdateCheckKey` is deliberately
+  not stamped (`UpdateChecker.kt:92-95`), so the next app open retries. Bounded by app
+  opens, not by a timer.
+
+## Device test plan — Galaxy S25 Ultra
+
+1. Settings → Updates → turn "Check for updates" on. Confirm the update card appears
+   (needs a release newer than the installed `versionCode`; otherwise fake it by
+   installing an older build).
+2. Do **not** dismiss it. Force stop InterTune from Android Settings → Apps, so the
+   process really dies rather than being backgrounded.
+3. Reopen within 6 hours. **Before the fix:** the badge is on the search bar but
+   Settings → Updates shows no card. **After the fix:** the card is there and "Skip this
+   version" works.
+4. Tap "Skip this version". Force stop, reopen inside the interval, confirm no card and
+   no badge, and confirm (via logcat, tag `UpdateChecker`) that no request was made — the
+   rate limit must still hold for the dismissed case.
+5. Turn update checks off. Force stop, reopen, confirm nothing is fetched at all.
+6. With no update pending, force stop and reopen several times inside the interval and
+   confirm from logcat that only the first open fetched — the rate limit is intact for
+   the ordinary case.
+
+## Verification status
+
+`UNVERIFIED — not compiled.` This environment has no Android SDK (`ANDROID_HOME` and
+`ANDROID_SDK_ROOT` are empty and no SDK exists at any of the usual paths), so
+`:app:compileCoreDebugKotlin` cannot run. The `:app` module has no JVM unit-test source
+set either, so no test was added. The change is a single boolean condition using a symbol
+already imported in the file.


### PR DESCRIPTION
Bookkeeping only — no code changes. Kept separate from the fix in #7 on purpose, so neither has to wait on the other.

Run 1 of the proactive bug scan (routine N2-A), so this creates the `.bug-scan/` scaffold rather than updating it.

## What's here

- **`index.json`** — what was scanned (`visionos-fix` @ `de158cf`) and, importantly, whether this environment can build. It cannot: `:app:compileCoreDebugKotlin` fails with `SDK location not found`, so every patch produced here is UNVERIFIED and the Verifiability dimension is capped at 6/25 for anything that is not pure JVM logic. That is recorded with the actual error rather than asserted, so a future run knows whether the capability has changed.
- **`baseline.json`** — every finding by fingerprint (`path#symbol#bug-class`) with its state, plus the candidates that were **discarded** and why. The discard list is deliberately part of the record: four of the seven turned out to be unchanged upstream code, and one was a Compose early-return that looked like a slot-table hazard and is not. Without that written down the next run pays to rediscover them.
- **`plans/`** — the plan for the one finding that was patched.
- **`RUNLOG.md`** — one line per run.

## How the scan surface was chosen

This checkout is shallow (54 commits) and shares no fetchable ancestor with `OuterTune/OuterTune`, so `merge-base` cannot separate our code from upstream's. Instead the surface was computed as a tree diff of `HEAD` against a **read-only** fetch of `OuterTune/OuterTune@dev` (`12f61da`) — 7 files that exist only here, plus 45 modified `*.kt` ranked by churn. Upstream was fetched by URL without adding a remote; nothing was written to it.

That distinction did real work this run: three of the strongest-looking candidates (an unreleased `MediaMetadataRetriever`, a network callback re-registered on recomposition, and dp-vs-pixel swipe offsets) are verbatim upstream code and were set aside for the upstream routine rather than filed here.

## Findings from this run

| # | Finding | Score | State |
|---|---|---|---|
| #4 | Update rate limit hides an update we already found, after a cold start | 81 | patched in #7 |
| #6 | Dynamic theme colour neither cancelled nor ordered | 78 | report-only |
| #5 | Stopping the loudness repair lets a second scan start | 76 | report-only |

Only #4 cleared the 80 patch bar. The other two are genuine and both have concrete failure paths, but with no build here neither could earn enough on verifiability to justify a second unverified patch — and the routine allows one code PR per run regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvJ88e8QnffJMFCDFfRLPh

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvJ88e8QnffJMFCDFfRLPh)_